### PR TITLE
Android Fixes

### DIFF
--- a/src/agenda/reservation-list/index.js
+++ b/src/agenda/reservation-list/index.js
@@ -234,7 +234,6 @@ class ReactComp extends Component {
         getItemLayout={(data, index) => (
           {length: this.theHeight, offset: this.theHeight * index, index}
         )}
-        initialScrollIndex={this.startIndex}
       />
     );
   }

--- a/src/calendar/day/multi-dot/style.js
+++ b/src/calendar/day/multi-dot/style.js
@@ -5,8 +5,10 @@ const STYLESHEET_ID = 'stylesheet.day.multiDot';
 
 export default function styleConstructor(theme={}) {
   const appStyle = {...defaultStyle, ...theme};
+  const margin = (Platform.OS === 'android') ? 2 : 0
   return StyleSheet.create({
     base: {
+      marginTop: margin,
       width: 32,
       height: 32,
       alignItems: 'center'


### PR DESCRIPTION
Added a margin fix to keep the 'dot' from getting cut off in Android. Had to remove `initialScrollIndex` since it was causing the `FlatList` render to hang on Android.