### PR TITLE
Added padding to calendar list header

### DIFF
--- a/src/calendar/style.js
+++ b/src/calendar/style.js
@@ -1,4 +1,6 @@
-import {StyleSheet} from 'react-native';
+import {
+  StyleSheet
+} from 'react-native';
 import * as defaultStyle from '../style';
 
 const STYLESHEET_ID = 'stylesheet.calendar.main';
@@ -9,6 +11,7 @@ export default function getStyle(theme={}) {
     container: {
       paddingLeft: 5,
       paddingRight: 5,
+      paddingTop: 8,
       backgroundColor: appStyle.calendarBackground
     },
     monthView: {


### PR DESCRIPTION
Adding top padding to the calendar list component keeps the `dot`s from getting cut off on Android.
![screenshot_20181119-095513](https://user-images.githubusercontent.com/8824846/48725506-46098c80-ebe1-11e8-9712-35c5fe4ac6fe.png)
